### PR TITLE
Replace github with gitlab in comment

### DIFF
--- a/hosts/gitlab.go
+++ b/hosts/gitlab.go
@@ -38,7 +38,7 @@ func NewGitlabClient(m *manager.Manager) (*Gitlab, error) {
 	return gitlabClient, err
 }
 
-// Scan will scan a github user or organization's repos.
+// Scan will scan a gitlab user or organization's repos.
 func (g *Gitlab) Scan() {
 	var (
 		projects []*gitlab.Project


### PR DESCRIPTION
Fixing a typo in the gitlab scan function from github to gitlab

### Description:
Explain the purpose of the PR.

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
